### PR TITLE
Fix occasional BlockingIOError in MacOS

### DIFF
--- a/terminalExec.py
+++ b/terminalExec.py
@@ -60,7 +60,7 @@ def getCharacterPosix():
   termios.tcsetattr(fd, termios.TCSANOW, newattr)
 
   oldflags = fcntl.fcntl(fd, fcntl.F_GETFL)
-  fcntl.fcntl(fd, fcntl.F_SETFL, oldflags | os.O_NONBLOCK)
+  fcntl.fcntl(fd, fcntl.F_SETFL, oldflags)
 
   try:        
     while True:            


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
In Terminal Window connected to pico, when I type help(), I was having BlockingIOError.

Checked the code and found no reason to use O_NONBLOCK for stdout. Having no problem without O_NONBLOCK so far.

## Does this close any currently open issues?
No.

## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*
This is the error I was having, in the middle of help() output screen.
> Traceback (most recent call last):
>   File "/Users/yjchun/conda/lib/python3.9/threading.py", line 954, in _bootstrap_inner
>     self.run()
>   File "/Users/yjchun/conda/lib/python3.9/threading.py", line 892, in run
>     self._target(*self._args, **self._kwargs)
>   File "/Users/yjchun/.vscode/extensions/chriswood.pico-go-1.4.3/terminalExec.py", line 127, in runServer
>     serviceConnection(key, mask)
>   File "/Users/yjchun/.vscode/extensions/chriswood.pico-go-1.4.3/terminalExec.py", line 47, in serviceConnection
>     boardInput(recv_data)
>   File "/Users/yjchun/.vscode/extensions/chriswood.pico-go-1.4.3/terminalExec.py", line 85, in boardInput
>     sys.stdout.write(data.decode("utf-8"))
> BlockingIOError: [Errno 35] write could not complete without blocking
> 


## Any other comments?


## Where has this been tested?
```
Pico-Go:      1.4.3
VS Code:      1.59.1
Electron:     13.1.7
Modules:      89
Node:         14.16.0
Platform:     darwin
Architecture: x64
Board:        Raspberry Pi Pico with RP2040
Firmware:     v1.16-262-g89145c6aa on 2021-09-01 (GNU 9.3.1 MinSizeRel)
```