### PR TITLE
Fix error : "TypeError: this.statusbar_buttons.push is not a function"

### DIFF
--- a/src/main/settings-wrapper.js
+++ b/src/main/settings-wrapper.js
@@ -145,7 +145,7 @@ export default class SettingsWrapper extends EventEmitter {
     this.timeout = 15000;
     this._setProjectConfig();
 
-    if (this.statusbar_buttons == undefined || this.statusbar_buttons == '') {
+    if (!Array.isArray(typeof this.statusbar_buttons)) {
       this.statusbar_buttons = ['status', 'connect', 'upload', 'download',
         'run', 'softreset'
       ];


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

When activating Pico-Go extension, the extension throw an error. To prevent this I have change the check from :

```javaScript 
    if (this.statusbar_buttons == undefined || this.statusbar_buttons == '') {
          this.statusbar_buttons = ['status', 'connect', 'upload', 'download',
            'run', 'softreset'
          ];
    }
```

to : 

```javascript
    if (!Array.isArray(typeof this.statusbar_buttons)) {
      this.statusbar_buttons = ['status', 'connect', 'upload', 'download',
        'run', 'softreset'
      ];
    }
```

## Does this close any currently open issues?

Close #113 

## Any relevant logs, error output, etc?

<img width="918" alt="Capture d’écran 2022-01-12 à 09 18 22" src="https://user-images.githubusercontent.com/2605774/149089696-bd483dff-3ac2-4487-9924-fe7711df32bd.png">

## Any other comments?


## Where has this been tested?

Tested in VSC debugger.

**Operating system:** macOS Monterey 12.1

**VSCode version:** 1.63.2

**Pico-Go version:** 1.4.3
